### PR TITLE
Women only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rb-readline'
   gem 'rspec-rails'
+  gem 'capybara', '~> 3.23'
+  gem 'selenium-webdriver'
+  gem 'webdrivers' 
 end
 
 group :development do
@@ -69,3 +72,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'nokogiri', '1.12.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.38.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -173,6 +182,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
@@ -284,6 +294,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -294,6 +305,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.8.1)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
@@ -318,14 +333,21 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -336,6 +358,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
+  capybara (~> 3.23)
   draper
   enum_help
   factory_bot_rails
@@ -345,6 +368,7 @@ DEPENDENCIES
   kaminari!
   letter_opener_web
   listen (~> 3.3)
+  nokogiri (= 1.12.5)
   pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
@@ -356,11 +380,13 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  selenium-webdriver
   sorcery
   spring
   sqlite3 (~> 1.4)
   tzinfo-data
   web-console (>= 4.1.0)
+  webdrivers
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -43,17 +43,11 @@ class EventsController < ApplicationController
   def show
     @event = Event.find(params[:id])
 
-    if @event.only_woman? && current_user&.gender != 'female'
-      flash[:alert] = 'This event is only for women.'
-      redirect_to events_path and return
-    end
-
     if @event.only_woman?
-      @can_join_event = current_user && !@event.attendees.include?(current_user) ? current_user.female? : false
+      @can_join_event = current_user && current_user.woman? && !@event.attendees.include?(current_user) ? true : false
     else
       @can_join_event = current_user && !@event.attendees.include?(current_user) ? true : false
     end
-
   end
 
   def edit

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -42,6 +42,18 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+
+    if @event.only_woman? && current_user&.gender != 'female'
+      flash[:alert] = 'This event is only for women.'
+      redirect_to events_path and return
+    end
+
+    if @event.only_woman?
+      @can_join_event = current_user && !@event.attendees.include?(current_user) ? current_user.female? : false
+    else
+      @can_join_event = current_user && !@event.attendees.include?(current_user) ? true : false
+    end
+
   end
 
   def edit
@@ -60,6 +72,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail, :only_woman)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :password, :password_confirmation, :gender)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,7 +10,6 @@ class Event < ApplicationRecord
   has_many :attendees, through: :attendances, class_name: 'User', source: :user
   has_many :bookmarks, dependent: :destroy
   has_one_attached :thumbnail
-  # has_many :joinable_users, -> { where(gender: 'female') }, through: :bookmarks, class_name: 'User', source: :user
 
   scope :future, -> { where('held_at > ?', Time.current) }
   scope :past, -> { where('held_at <= ?', Time.current) }
@@ -30,18 +29,6 @@ class Event < ApplicationRecord
   def future?
     !past?
   end
-
-  # def only_woman?
-  #   user.female?
-  # end
-
-  # def joinable_users
-  #   if only_woman?
-  #     User.where(gender: 'female')
-  #   else
-  #     User.all
-  #   end
-  # end
 
   def only_woman?
     only_woman

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,9 +10,12 @@ class Event < ApplicationRecord
   has_many :attendees, through: :attendances, class_name: 'User', source: :user
   has_many :bookmarks, dependent: :destroy
   has_one_attached :thumbnail
+  # has_many :joinable_users, -> { where(gender: 'female') }, through: :bookmarks, class_name: 'User', source: :user
 
   scope :future, -> { where('held_at > ?', Time.current) }
   scope :past, -> { where('held_at <= ?', Time.current) }
+# 女性限定のイベントを表示するためのスコープを追加
+  scope :only_women, -> { where(only_woman: true) }
 
   with_options presence: true do
     validates :title
@@ -26,5 +29,21 @@ class Event < ApplicationRecord
 
   def future?
     !past?
+  end
+
+  # def only_woman?
+  #   user.female?
+  # end
+
+  # def joinable_users
+  #   if only_woman?
+  #     User.where(gender: 'female')
+  #   else
+  #     User.all
+  #   end
+  # end
+
+  def only_woman?
+    only_woman
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   scope :allowing_liked_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.liked_event) }
 
+  enum gender: { other: 0, male: 1, female: 2 }
+
   def owner?(event)
     event.user_id == id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,11 @@ class User < ApplicationRecord
   scope :allowing_liked_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.liked_event) }
 
-  enum gender: { other: 0, male: 1, female: 2 }
+  enum gender: { other: 0, man: 1, woman: 2 }
+
+  def self.genders_i18n
+    genders.keys.map { |key| [I18n.t("enums.user.gender.#{key}"), key] }.to_h
+  end
 
   def owner?(event)
     event.user_id == id

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -7,10 +7,10 @@
       <h4 class="card-title fw-bold">
         <%= link_to event.title, event_path(event)  %>
       </h4>
-      <p class="card-text"><%= event.content %></p>
       <% if event.only_woman? %>
         <p class="card-text"><strong>女性限定</strong></p>
       <% end %>
+      <p class="card-text"><%= event.content %></p>
       <hr />
       <div class="d-flex justify-content-between">
         <div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -8,6 +8,9 @@
         <%= link_to event.title, event_path(event)  %>
       </h4>
       <p class="card-text"><%= event.content %></p>
+      <% if event.only_woman? %>
+        <p class="card-text"><strong>女性限定</strong></p>
+      <% end %>
       <hr />
       <div class="d-flex justify-content-between">
         <div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,5 +21,9 @@
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>
     <%= image_tag f.object.decorate.thumbnail, id: 'preview-target', class: 'w-100 border' %>
   </div>
+  <div class="mb-3">
+    <%= f.label :only_woman %>
+    <%= f.check_box :only_woman %>
+  </div>
   <%= f.submit '登録', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -21,9 +21,11 @@
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>
     <%= image_tag f.object.decorate.thumbnail, id: 'preview-target', class: 'w-100 border' %>
   </div>
-  <div class="mb-3">
-    <%= f.label :only_woman %>
-    <%= f.check_box :only_woman %>
-  </div>
+  <% if current_user&.woman? %>
+    <div class="mb-3">
+      <%= f.label :only_woman %>
+      <%= f.check_box :only_woman %>
+    </div>
+  <% end %>
   <%= f.submit '登録', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,15 +16,15 @@
             </h1>
             <% if logged_in? %>
               <div class="ms-auto">
+                <% if @event.only_woman? %>
+                  <p class="card-text"><strong>女性限定</strong></p>
+                <% end %>
                 <% if current_user.own?(@event) %>
                   <span class="me-2">
                     <%= link_to edit_event_path(@event) do  %>
                       <i class="bi bi-pencil"></i>
                     <% end %>
                   </span>
-                <% end %>
-                <% if @event.only_woman? %>
-                  <p class="card-text"><strong>女性限定</strong></p>
                 <% end %>
                 <span id="js-event-bookmark-<%= @event.id %>">
                   <% if current_user.bookmarked?(@event) %>
@@ -95,7 +95,7 @@
                               method: :delete,
                               data: { confirm: 'キャンセルします' }
                   %>
-                <% else %>
+                <% elsif !@event.only_woman? || (current_user.woman? && @event.only_woman?) %>
                   <%= link_to 'このもくもく会に参加する',
                               event_attendance_url(@event),
                               class: 'btn btn-primary',

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,6 +23,9 @@
                     <% end %>
                   </span>
                 <% end %>
+                <% if @event.only_woman? %>
+                  <p class="card-text"><strong>女性限定</strong></p>
+                <% end %>
                 <span id="js-event-bookmark-<%= @event.id %>">
                   <% if current_user.bookmarked?(@event) %>
                     <%= render 'events/bookmarks/unbookmark', event: @event %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -33,7 +33,7 @@
             </div>
             <div class="mb-3">
               <%= f.label :gender %>
-              <%= f.select :gender, User.genders.keys.to_a.map { |gender| [User.human_attribute_name("gender.#{gender}"), gender] } %>
+              <%= f.select :gender, User.genders_i18n %>
             </div>
             <div class="mb-3">
               <div class="form-check">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -32,6 +32,10 @@
               <%= f.password_field :password_confirmation, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender %>
+              <%= f.select :gender, User.genders.keys.to_a.map { |gender| [User.human_attribute_name("gender.#{gender}"), gender] } %>
+            </div>
+            <div class="mb-3">
               <div class="form-check">
                 <input type="checkbox" class="form-check-input" id="agreeCheck">
                 <label class="form-check-label" for="agreeCheck"><span>I agree to the <a href="terms-condition-page.html">Terms of

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,10 @@
 ja:
   enums:
+    user:
+      gender:
+        other: "その他"
+        man: "男性"
+        woman: "女性"
     notification_timing:
       timing:
         created_event: イベントが作成された時

--- a/db/migrate/20230311111808_add_gender_to_user.rb
+++ b/db/migrate/20230311111808_add_gender_to_user.rb
@@ -1,0 +1,5 @@
+class AddGenderToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230311111809_add_only_woman_to_event.rb
+++ b/db/migrate/20230311111809_add_only_woman_to_event.rb
@@ -1,0 +1,5 @@
+class AddOnlyWomanToEvent < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :only_woman, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2023_03_11_111809) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "only_woman", default: false, null: false
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
@@ -135,6 +136,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,4 +8,9 @@ FactoryBot.define do
     prefecture_id { [*1..47].sample }
     user
   end
+
+  trait :woman_only_event do
+    only_woman { true }
+    user { FactoryBot.create(:user, :woman_user) }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     name { Faker::Name.name }
     password { 'password' }
     password_confirmation { 'password' }
+
+    trait :woman_user do
+      gender { :woman }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,6 +24,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -65,4 +67,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include Sorcery::TestHelpers::Rails::Request, type: :request
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1920, 1080]
+  end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login(user)
+    visit login_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe "Events", type: :system do
+  let(:user)  { create :user }
+  let(:event) { create :event }
+
+  describe 'event関係' do
+    context 'index' do
+      before do
+        login(user)
+      end
+
+      it '一覧ページにアクセスすると、イベント一覧を閲覧できる。' do
+        event
+        visit root_path
+        expect(page).to have_content(event.title)
+        expect(page).to have_content(event.prefecture.name)
+        expect(page).to have_content(event.user.name)
+      end
+    end
+
+    context 'new→create' do
+      before do
+        login(user)
+      end
+
+      it '新しくイベント(未来)を作成できる。トップページでそれを確認できる。"直近イベント"でそれを確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+
+        visit future_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it '新しくイベント(過去)を作成できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+    end
+
+    context 'edit→update' do
+      before do
+        login(event.user)
+      end
+
+      it 'イベント(未来)を更新できる。トップページでそれを確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'イベント(過去)を更新できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(event.user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  let(:user) { create :user }
+
+  describe 'session関係' do
+    it '登録されているユーザーでログインを行い、イベント一覧ページにリダイレクトされる。' do
+      visit login_path
+      fill_in 'email', with: user.email
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('もくもく会を作る')
+    end
+
+    it '登録されていないユーザーでログインを行うと、ログインページが表示される。' do
+      visit login_path
+      fill_in 'email', with: 'hogehogee4674@exmaple.com'
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('Sign up')
+      expect(page).not_to have_content('I agree to the Terms of Service and Privacy Policy.')
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  describe 'Sign up関係' do
+    context '成功系' do
+      it 'Sign upを行い、ログイン処理を行うとイベント一覧ページにリダイレクトされる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+      end
+
+      it 'Sign up時に性別を選ばないで登録すると、その他として登録される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'other'
+      end
+
+      it 'Sign up時に性別(男性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '男性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'man'
+      end
+
+      it 'Sign up時に性別(女性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '女性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'woman'
+      end
+    end
+
+    context '失敗系' do
+      it 'passwordが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password, password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+    end
+  end
+end

--- a/spec/system/woman_only_events_spec.rb
+++ b/spec/system/woman_only_events_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe "WomanOnlyEvents", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman_user }
+  let(:event) { create :event }
+  let(:woman_only_event) { create :event, :woman_only_event }
+
+  describe '女性限定event' do
+    context '女性以外のユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(user)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントには参加できない。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).not_to have_content('このもくもく会に参加する')
+      end
+
+      it '新規イベント作成時に"Only woman"チェックボックスが表示されない。' do
+        visit new_event_path
+        expect(page).to have_content('もくもく会作成')
+        expect(page).not_to have_content('Only woman')
+      end
+    end
+
+    context '女性ユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(woman)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントに参加できる。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).to have_content('このもくもく会に参加する')
+
+        click_link 'このもくもく会に参加する'
+      end
+
+      it '"女性限定"イベントを作成できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントを更新できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        visit edit_event_path(woman.events.last)
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+    end
+  end
+end

--- a/spec/system/woman_users_spec.rb
+++ b/spec/system/woman_users_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "WomanUsers", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman}
+  let(:event) { create :event }
+
+  describe 'womanがログインした場合' do
+    before do
+      login(woman)
+      event
+    end
+
+    it '一覧ページにアクセスすると、イベント一覧にアクセスでき、イベント(一般)を閲覧できる。' do
+      visit root_path
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.prefecture.name)
+      expect(page).to have_content(event.user.name)
+    end
+
+    it '一般イベントに参加することができる。' do
+      visit event_path(event)
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.user.name)
+      expect(page).not_to have_content('女性限定')
+      expect(page).to have_content('このもくもく会に参加する')
+    end
+  end
+end


### PR DESCRIPTION
「事業をエンジニアリングしよう ②実装」の機能実装をしました。

### **選択した事業側の課題**
サービス登録者数の内、男性60%に対して、女性は40%。一方で、サービス内のもくもく会に参加した人の比率は、男性90%：女性10%と大きな差が出ています。もっと女性が使いやすいようなサービス設計にする必要があるのではないか？

【実装方針】
- [x]  ユーザー登録時に手入力やチェックボックス入力ではなく、セレクト形式で性別登録できる。
- [x]  イベント作成画面にOnly womanのチェックボックスにチェックを入れるだけで女性限定イベントを作できる。
- [x]  ユーザーが女性以外の場合、イベント作成時にOnly womanは表示されず、女性限定イベントが作成できない。
- [x]  女性限定イベントには女性のみが参加できる。
- [x]  女性以外の場合、女性限定イベントの詳細ページを開いた際に「このもくもく会に参加する」が表示されない。
- [x]  女性限定イベントは一覧・詳細画面にて「女性限定」が表記される。
- [x]  【注意点】
    - [x]  イベントが女性限定であるかを判定するカラムは"only_woman"とする
    - [x]  ユーザーの性別登録のカラムは"gender"とする
    - [x]  ユーザー登録時の性別のセレクト部分はenumを使って「その他・男性・女性」が表示される（その際に特に操作が無ければ"その他"が選択される）

【Gemfile】
Testグループに以下のgemを追加
- gem 'capybara', '~> 3.23'
- gem 'selenium-webdriver'
- gem 'webdrivers' 
Gemfileの最下部に以下のgemを追加
- gem 'nokogiri', '1.12.5'`

【テスト結果】
![テスト結果](https://user-images.githubusercontent.com/76391902/224517260-3c7657e4-4c97-4161-8259-70581d33b231.png)
